### PR TITLE
优化首页输出默认特色图字段

### DIFF
--- a/includes/api/ram-rest-settings-controller.php
+++ b/includes/api/ram-rest-settings-controller.php
@@ -63,9 +63,10 @@ class RAM_REST_Options_Controller  extends WP_REST_Controller{
 
         $zanImageurl=get_option('wf_zan_imageurl');
         $logoImageurl=get_option('wf_logo_imageurl');
+        $postImageUrl=get_option("wf_poster_imageurl");
         $result["zanImageurl"] =$zanImageurl;
         $result["logoImageurl"] =$logoImageurl;
-
+        $result["postImageUrl"] =$postImageUrl;
         $swipe_nav =$expand['swipe_nav'];
         $selected_nav=$expand['selected_nav'];       
         $_expand['swipe_nav']=$swipe_nav;


### PR DESCRIPTION
优化首页输出默认特色图字段，当文章没有图片时优先取后台设置的默认缩略图